### PR TITLE
Fix wrong type of object assigned in URL constructor

### DIFF
--- a/libs/client/url.py
+++ b/libs/client/url.py
@@ -40,7 +40,7 @@ class URL(object):
   """
 
   def __init__(self, url):
-    self.__url = url
+    self.__url = client.URL(url)
 
   def __str__(self):
     return str(self.__url)


### PR DESCRIPTION
This should also be merged into the current master.

Thanks, 
Elvin
