### PR TITLE
enable source distribution packaging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ build
 .pydevproject
 .cproject
 *.py[co]
+MANIFEST
+dist

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,7 @@
+include README.rst
+include VERSION_INFO
+include genversion.sh
+recursive-include tests *
+recursive-include examples *.py
+recursive-include docs *
+recursive-include src *

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ version, err = p.communicate()
 print version
 
 setup( name             = 'pyxrootd',
-       version          = version,
+       version          = version.strip(),
        author           = 'XRootD Developers',
        author_email     = 'xrootd-dev@slac.stanford.edu',
        url              = 'http://xrootd.org',


### PR DESCRIPTION
* Run `python setup.py sdist` to generate a source distribution package

* Omits the newline at the end of the version number generated by
  `genversion.sh`