### PR TITLE
C++11 flag in extra_compile_args

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup( name             = 'pyxrootd',
                sources   = sources,
                depends   = depends,
                libraries = ['XrdCl', 'XrdUtils', 'dl'],
-               extra_compile_args = ['-g'],
+               extra_compile_args = ['-g', '-std=c++11'],
                include_dirs = [xrdincdir],
                library_dirs = [xrdlibdir]
                )


### PR DESCRIPTION
Hi!

I had to set the `-std=c++11` flag to compile with the most recent xrootd on a Scientific Linux 7 machine. Maybe it's good to have this upstream so other users can install with less effort?

Thanks and cheers!
Jonas